### PR TITLE
Added get_all_leagues method

### DIFF
--- a/xmlsoccer/client.py
+++ b/xmlsoccer/client.py
@@ -1,16 +1,19 @@
 import requests
 
-from .parsers import parse_odds, parse_fixtures
-
-
-ENDPOINT = "http://www.xmlsoccer.com/FootballData.asmx"
+from .parsers import *
 
 
 class Client:
 
-    def __init__(self, key):
+    def __init__(self, key, endpoint='http://www.xmlsoccer.com/FootballData.asmx'):
         self._key = key
+        self._endpoint = endpoint
 
+    def get_all_leagues(self):
+        """Get all available leagues."""
+        res = self._get("GetAllLeagues")
+        return parse_leagues(res)
+        
     def get_odds(self, *, fid):
         """Get all odds for a given fixture id."""
         res = self._get("GetAllOddsByFixtureMatchId", fixtureMatch_Id=fid)
@@ -33,6 +36,6 @@ class Client:
 
     def _get(self, method, **payload):
         payload["ApiKey"] = self._key
-        url = "{}/{}".format(ENDPOINT, method)
+        url = "{}/{}".format(self._endpoint, method)
         res = requests.post(url, data=payload)
         return res.content

--- a/xmlsoccer/client.py
+++ b/xmlsoccer/client.py
@@ -1,3 +1,4 @@
+from datetime import date
 import requests
 
 from .parsers import *
@@ -19,11 +20,31 @@ class Client:
         res = self._get("GetAllOddsByFixtureMatchId", fixtureMatch_Id=fid)
         return parse_odds(res)
 
-    def get_fixtures(self, *, league, season):
+    def get_fixtures(self, *, league, season=''):
         """Get matches given a league and a season."""
         res = self._get(
                 "GetFixturesByLeagueAndSeason",
                 seasonDateString=season,
+                league=league)
+        return parse_fixtures(res)
+        
+    def get_fixture(self, *, fid):
+        """Get match by ID."""
+        res = self._get(
+                "GetFixtureMatchByID",
+                id=fid)
+        return parse_fixtures(res)
+        
+    def get_fixtures_by_date_interval(self, *, league, start=None, end=None):
+        """Get matches given a league and a start/end date interval in ISO format yyyy-mm-dd."""
+        if not start:
+            start = date.today().isoformat()
+        if not end:
+            end = date(date.today().year, 12, 31).isoformat()
+        res = self._get(
+                "GetFixturesByDateIntervalAndLeague",
+                startDateString=start,
+                endDateString=end,
                 league=league)
         return parse_fixtures(res)
 

--- a/xmlsoccer/parsers.py
+++ b/xmlsoccer/parsers.py
@@ -24,7 +24,8 @@ def parse_odds(text):
                 datum["away_odds"] = float(x.text)
             elif x.tag == "Handicap":
                 datum["handicap"] = float(x.text)
-        data.append(datum)
+        if datum:
+            data.append(datum)
     return data
 
 
@@ -56,5 +57,35 @@ def parse_fixtures(text):
                 datum["away_goals"] = int(x.text)
             elif x.tag == "Location":
                 datum["location"] = x.text
-        data.append(datum)
+        if datum:
+            data.append(datum)
+    return data
+
+
+def parse_leagues(text):
+    root = etree.XML(text)
+    data = list()
+    for odds_elem in root:
+        datum = dict()
+        for x in odds_elem:
+            if x.tag == "Id":
+                datum["id"] = int(x.text)
+            elif x.tag == "Name":
+                datum["name"] = x.text
+            elif x.tag == "Country":
+                datum["country"] = x.text
+            elif x.tag == "Historical_Data":
+                datum["historical_data"] = utils.parse_bool(x.text)
+            elif x.tag == "Fixtures":
+                datum["fixtures"] = utils.parse_bool(x.text)
+            elif x.tag == "Livescore":
+                datum["livescore"] = utils.parse_bool(x.text)
+            elif x.tag == "NumberOfMatches":
+                datum["number_of_matches"] = int(x.text)
+            elif x.tag == "LatestMatch":
+                datum["latest_match"] = utils.parse_dt(x.text)
+            elif x.tag == "IsCup":
+                datum["is_cup"] = utils.parse_bool(x.text)
+        if datum:
+            data.append(datum)
     return data

--- a/xmlsoccer/utils.py
+++ b/xmlsoccer/utils.py
@@ -5,3 +5,6 @@ def parse_dt(s):
         return datetime.strptime(s.replace(":", ""), "%Y-%m-%dT%H%M%S%z")
     except ValueError:
         return datetime.strptime(s[:19], "%Y-%m-%dT%H:%M:%S")
+
+def parse_bool(s):
+    return True if s == 'Yes' else False


### PR DESCRIPTION
Hi, I added one more method to the Client class (get_all_leagues), one more parser to handle a response from that method and one little util to replace "Yes" or "false" strings from xml response to python's True or False words.

Also, for now I'm using xmlsoccer.com's demo key and I make requests to it's demo API url. So I think that for people like me will be useful to give avaibility to set they demo endpoint to Client instanse. 

This is my example:

```
import configparser
from xmlsoccer import *


def process():
    leagues = cli.get_all_leagues()
    for league in leagues:
        print(league)

if __name__ == "__main__":
    config = configparser.ConfigParser()
    config.read('config.ini')

    key = config['xmlsoccer']['API_KEY']
    endpoint = config['xmlsoccer']['API_URL_DEMO']

    cli = Client(key, endpoint=endpoint)

    process()
```